### PR TITLE
[FIX] Cleanup code

### DIFF
--- a/dbr_go18_test.go
+++ b/dbr_go18_test.go
@@ -4,11 +4,10 @@ package dbr
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/mailru/dbr/dialect"
-
-	"database/sql"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/load.go
+++ b/load.go
@@ -109,7 +109,7 @@ func mapExtractor(columns []string, value reflect.Value) []interface{} {
 		value.Set(reflect.MakeMap(value.Type()))
 	}
 	m := value.Convert(typeKeyValueMap).Interface().(keyValueMap)
-	var ptr []interface{}
+	var ptr = make([]interface{}, 0, len(columns))
 	for _, c := range columns {
 		ptr = append(ptr, &kvScanner{column: c, m: m})
 	}

--- a/load_test.go
+++ b/load_test.go
@@ -31,8 +31,8 @@ func TestLoad(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		var values []driver.Value
 		session, dbmock := newSessionMock()
-		values := []driver.Value{}
 		for _, c := range tc.columns {
 			values = append(values, c)
 		}

--- a/types.go
+++ b/types.go
@@ -205,11 +205,11 @@ func (n *NullTime) Scan(value interface{}) error {
 		return nil
 	case []byte:
 		n.Time, err = parseDateTime(string(v), time.UTC)
-		n.Valid = (err == nil)
+		n.Valid = err == nil
 		return err
 	case string:
 		n.Time, err = parseDateTime(v, time.UTC)
-		n.Valid = (err == nil)
+		n.Valid = err == nil
 		return err
 	}
 


### PR DESCRIPTION
- sort imports
- unwrap (not needed)
- use var instead
- prealloc
- typo in `indent`