### PR TITLE
Add dialect name functions to dialects (clickhouse like)

### DIFF
--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -80,6 +80,10 @@ func (d mysql) Limit(offset, limit int64) string {
 	return fmt.Sprintf("LIMIT %d,%d", offset, limit)
 }
 
+func (d mysql) String() string {
+	return "mysql"
+}
+
 func (d mysql) Prewhere() string {
 	return ""
 }

--- a/dialect/postgresql.go
+++ b/dialect/postgresql.go
@@ -51,6 +51,10 @@ func (d postgreSQL) Limit(offset, limit int64) string {
 	return fmt.Sprintf("LIMIT %d OFFSET %d", limit, offset)
 }
 
+func (d postgreSQL) String() string {
+	return "postgres"
+}
+
 func (d postgreSQL) Prewhere() string {
 	return ""
 }

--- a/dialect/sqlite3.go
+++ b/dialect/sqlite3.go
@@ -54,6 +54,10 @@ func (d sqlite3) Limit(offset, limit int64) string {
 	return fmt.Sprintf("LIMIT %d OFFSET %d", limit, offset)
 }
 
+func (d sqlite3) String() string {
+	return "sqlite3"
+}
+
 func (d sqlite3) Prewhere() string {
 	return ""
 }


### PR DESCRIPTION
По аналогии со структурой clickhouse добавил в остальные диалекты метод `String()`, возвращающий название драйвера.

Существующий пример из диалекта clickhouse
```
func (d clickhouse) String() string {
	return "clickhouse"
}
```