### PR TITLE
Populate insert and update columns from struct values

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -152,13 +152,23 @@ func (b *insertStmt) Values(value ...interface{}) InsertStmt {
 	return b
 }
 
-// Record adds a tuple for columns from a struct
+// Record adds a tuple for columns from a struct if no columns where
+// specified yet for this insert, the record fields will be used to populate the columns.
 func (b *insertStmt) Record(structValue interface{}) InsertStmt {
 	v := reflect.Indirect(reflect.ValueOf(structValue))
 
 	if v.Kind() == reflect.Struct {
 		var value []interface{}
 		m := structMap(v.Type())
+
+		// populate columns from available record fields
+		// if no columns were specified up to this point
+		if len(b.Column) == 0 {
+			for key := range m {
+				b.Column = append(b.Column, key)
+			}
+		}
+
 		for _, key := range b.Column {
 			if index, ok := m[key]; ok {
 				value = append(value, v.FieldByIndex(index).Interface())
@@ -168,6 +178,7 @@ func (b *insertStmt) Record(structValue interface{}) InsertStmt {
 		}
 		b.Values(value...)
 	}
+
 	return b
 }
 

--- a/insert.go
+++ b/insert.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"sort"
 )
 
 // ConflictStmt is ` ON CONFLICT ...` part of InsertStmt
@@ -164,9 +165,13 @@ func (b *insertStmt) Record(structValue interface{}) InsertStmt {
 		// populate columns from available record fields
 		// if no columns were specified up to this point
 		if len(b.Column) == 0 {
+			b.Column = make([]string, 0, len(m))
 			for key := range m {
 				b.Column = append(b.Column, key)
 			}
+
+			// ensure that the column ordering is deterministic
+			sort.Strings(b.Column)
 		}
 
 		for _, key := range b.Column {

--- a/insert_test.go
+++ b/insert_test.go
@@ -34,7 +34,7 @@ func TestInsertRecordNoColumns(t *testing.T) {
 	err := builder.Build(dialect.MySQL, buf)
 	assert.NoError(t, err)
 	assert.Equal(t, "INSERT INTO `table` (`a`,`b`) VALUES (?,?), (?,?)", buf.String())
-	assert.Equal(t, []interface{}{1, "one", 2, "two"}, buf.Value())
+	assert.Equal(t, []interface{}{2, "two", 1, "one"}, buf.Value())
 }
 
 func TestInsertOnConflictStmt(t *testing.T) {

--- a/insert_test.go
+++ b/insert_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 type insertTest struct {
+	v string
 	A int
 	C string `db:"b"`
 }
@@ -18,6 +19,18 @@ func TestInsertStmt(t *testing.T) {
 		A: 2,
 		C: "two",
 	})
+	err := builder.Build(dialect.MySQL, buf)
+	assert.NoError(t, err)
+	assert.Equal(t, "INSERT INTO `table` (`a`,`b`) VALUES (?,?), (?,?)", buf.String())
+	assert.Equal(t, []interface{}{1, "one", 2, "two"}, buf.Value())
+}
+
+func TestInsertRecordNoColumns(t *testing.T) {
+	buf := NewBuffer()
+	builder := InsertInto("table").Record(&insertTest{
+		A: 2,
+		C: "two",
+	}).Values(1, "one")
 	err := builder.Build(dialect.MySQL, buf)
 	assert.NoError(t, err)
 	assert.Equal(t, "INSERT INTO `table` (`a`,`b`) VALUES (?,?), (?,?)", buf.String())

--- a/select_builder.go
+++ b/select_builder.go
@@ -12,26 +12,26 @@ type SelectBuilder interface {
 	loader
 	typesLoader
 
-	From(table interface{}) SelectBuilder
+	As(alias string) Builder
 	Distinct() SelectBuilder
-	Prewhere(query interface{}, value ...interface{}) SelectBuilder
-	Where(query interface{}, value ...interface{}) SelectBuilder
-	Having(query interface{}, value ...interface{}) SelectBuilder
-	GroupBy(col ...string) SelectBuilder
-	OrderAsc(col string) SelectStmt
-	OrderDesc(col string) SelectStmt
-	Limit(n uint64) SelectBuilder
-	Offset(n uint64) SelectBuilder
 	ForUpdate() SelectBuilder
+	From(table interface{}) SelectBuilder
+	FullJoin(table, on interface{}) SelectBuilder
+	GroupBy(col ...string) SelectBuilder
+	Having(query interface{}, value ...interface{}) SelectBuilder
+	InTimezone(loc *time.Location) SelectBuilder
 	Join(table, on interface{}) SelectBuilder
 	LeftJoin(table, on interface{}) SelectBuilder
-	RightJoin(table, on interface{}) SelectBuilder
-	FullJoin(table, on interface{}) SelectBuilder
-	As(alias string) Builder
+	Limit(n uint64) SelectBuilder
+	Offset(n uint64) SelectBuilder
+	OrderAsc(col string) SelectBuilder
+	OrderBy(col string) SelectBuilder
+	OrderDesc(col string) SelectBuilder
 	OrderDir(col string, isAsc bool) SelectBuilder
 	Paginate(page, perPage uint64) SelectBuilder
-	OrderBy(col string) SelectBuilder
-	InTimezone(loc *time.Location) SelectBuilder
+	Prewhere(query interface{}, value ...interface{}) SelectBuilder
+	RightJoin(table, on interface{}) SelectBuilder
+	Where(query interface{}, value ...interface{}) SelectBuilder
 }
 
 type selectBuilder struct {
@@ -283,12 +283,14 @@ func (b *selectBuilder) InTimezone(loc *time.Location) SelectBuilder {
 	return b
 }
 
-func (b *selectBuilder) OrderAsc(col string) SelectStmt {
-	return b.selectStmt.OrderAsc(col)
+func (b *selectBuilder) OrderAsc(col string) SelectBuilder {
+	b.selectStmt.OrderAsc(col)
+	return b
 }
 
-func (b *selectBuilder) OrderDesc(col string) SelectStmt {
-	return b.selectStmt.OrderDesc(col)
+func (b *selectBuilder) OrderDesc(col string) SelectBuilder {
+	b.selectStmt.OrderDesc(col)
+	return b
 }
 
 // As creates alias for select statement

--- a/update.go
+++ b/update.go
@@ -116,10 +116,9 @@ func (b *updateStmt) SetMap(m map[string]interface{}) UpdateStmt {
 // SetRecord specifies a record with field and values to set
 func (b *updateStmt) SetRecord(structValue interface{}) UpdateStmt {
 	v := reflect.Indirect(reflect.ValueOf(structValue))
+
 	if v.Kind() == reflect.Struct {
 		sm := structMap(v.Type())
-		// populate columns from available record fields
-		// if no columns were specified up to this point
 
 		for col, index := range sm {
 			b.Set(col, v.FieldByIndex(index).Interface())

--- a/update.go
+++ b/update.go
@@ -9,6 +9,7 @@ type UpdateStmt interface {
 	Where(query interface{}, value ...interface{}) UpdateStmt
 	Set(column string, value interface{}) UpdateStmt
 	SetMap(m map[string]interface{}) UpdateStmt
+	SetRecord(structValue interface{}) UpdateStmt
 }
 
 type updateStmt struct {

--- a/update.go
+++ b/update.go
@@ -1,5 +1,7 @@
 package dbr
 
+import "reflect"
+
 // UpdateStmt builds `UPDATE ...`
 type UpdateStmt interface {
 	Builder
@@ -107,5 +109,21 @@ func (b *updateStmt) SetMap(m map[string]interface{}) UpdateStmt {
 	for col, val := range m {
 		b.Set(col, val)
 	}
+	return b
+}
+
+// SetRecord specifies a record with field and values to set
+func (b *updateStmt) SetRecord(structValue interface{}) UpdateStmt {
+	v := reflect.Indirect(reflect.ValueOf(structValue))
+	if v.Kind() == reflect.Struct {
+		sm := structMap(v.Type())
+		// populate columns from available record fields
+		// if no columns were specified up to this point
+
+		for col, index := range sm {
+			b.Set(col, v.FieldByIndex(index).Interface())
+		}
+	}
+
 	return b
 }

--- a/update_test.go
+++ b/update_test.go
@@ -17,6 +17,17 @@ func TestUpdateStmt(t *testing.T) {
 	assert.Equal(t, []interface{}{1, 2}, buf.Value())
 }
 
+func TestUpdateStmtSetRecord(t *testing.T) {
+	record := struct{ A int }{A: 1}
+	buf := NewBuffer()
+	builder := Update("table").SetRecord(&record).Where(Eq("b", 2))
+	err := builder.Build(dialect.MySQL, buf)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "UPDATE `table` SET `a` = ? WHERE (`b` = ?)", buf.String())
+	assert.Equal(t, []interface{}{1, 2}, buf.Value())
+}
+
 func BenchmarkUpdateValuesSQL(b *testing.B) {
 	buf := NewBuffer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This change allows update and insert statements without columns specification by populating them from the fields of provided struct values.