### PR TITLE
select: add support for skip locked

### DIFF
--- a/select.go
+++ b/select.go
@@ -15,6 +15,7 @@ type SelectStmt interface {
 	Limit(n uint64) SelectStmt
 	Offset(n uint64) SelectStmt
 	ForUpdate() SelectStmt
+	SkipLocked() SelectStmt
 	Join(table, on interface{}) SelectStmt
 	LeftJoin(table, on interface{}) SelectStmt
 	RightJoin(table, on interface{}) SelectStmt
@@ -37,9 +38,10 @@ type selectStmt struct {
 	HavingCond   []Builder
 	Order        []Builder
 
-	LimitCount  int64
-	OffsetCount int64
-	IsForUpdate bool
+	LimitCount   int64
+	OffsetCount  int64
+	IsForUpdate  bool
+	IsSkipLocked bool
 }
 
 // Build builds `SELECT ...` in dialect
@@ -155,6 +157,11 @@ func (b *selectStmt) Build(d Dialect, buf Buffer) error {
 	if b.IsForUpdate {
 		buf.WriteString(" FOR UPDATE")
 	}
+
+	if b.IsSkipLocked {
+		buf.WriteString(" SKIP LOCKED")
+	}
+
 	return nil
 }
 
@@ -269,6 +276,12 @@ func (b *selectStmt) Offset(n uint64) SelectStmt {
 // ForUpdate adds `FOR UPDATE`
 func (b *selectStmt) ForUpdate() SelectStmt {
 	b.IsForUpdate = true
+	return b
+}
+
+// SkipLocked adds `SKIP LOCKED`
+func (b *selectStmt) SkipLocked() SelectStmt {
+	b.IsSkipLocked = true
 	return b
 }
 

--- a/select_builder.go
+++ b/select_builder.go
@@ -31,6 +31,7 @@ type SelectBuilder interface {
 	Paginate(page, perPage uint64) SelectBuilder
 	Prewhere(query interface{}, value ...interface{}) SelectBuilder
 	RightJoin(table, on interface{}) SelectBuilder
+	SkipLocked() SelectBuilder
 	Where(query interface{}, value ...interface{}) SelectBuilder
 }
 
@@ -274,6 +275,12 @@ func (b *selectBuilder) Where(query interface{}, value ...interface{}) SelectBui
 // ForUpdate adds lock via FOR UPDATE
 func (b *selectBuilder) ForUpdate() SelectBuilder {
 	b.selectStmt.ForUpdate()
+	return b
+}
+
+// SkipLocked skips locked rows via SKIP LOCKED
+func (b *selectBuilder) SkipLocked() SelectBuilder {
+	b.selectStmt.SkipLocked()
 	return b
 }
 

--- a/select_test.go
+++ b/select_test.go
@@ -21,11 +21,12 @@ func TestSelectStmt(t *testing.T) {
 		OrderAsc("f").
 		Limit(3).
 		Offset(4).
-		ForUpdate()
+		ForUpdate().
+		SkipLocked()
 
 	err := builder.Build(dialect.ClickHouse, bufClickHouse) // because this lib is clickhouse first.
 	assert.NoError(t, err)
-	assert.Equal(t, "SELECT DISTINCT a, b FROM ? LEFT JOIN `table2` ON table.a1 = table.a2 PREWHERE (`c1` = ?) WHERE (`c2` = ?) GROUP BY d HAVING (`e` = ?) ORDER BY f ASC LIMIT 4,3 FOR UPDATE", bufClickHouse.String())
+	assert.Equal(t, "SELECT DISTINCT a, b FROM ? LEFT JOIN `table2` ON table.a1 = table.a2 PREWHERE (`c1` = ?) WHERE (`c2` = ?) GROUP BY d HAVING (`e` = ?) ORDER BY f ASC LIMIT 4,3 FOR UPDATE SKIP LOCKED", bufClickHouse.String())
 	assert.Equal(t, 4, len(bufClickHouse.Value()))
 
 	err = builder.Build(dialect.MySQL, bufMySQL)


### PR DESCRIPTION
This change adds support for SKIP LOCKED.

Closes #30 