### PR TITLE
Check errors in Load method

### DIFF
--- a/load.go
+++ b/load.go
@@ -51,7 +51,7 @@ func Load(rows *sql.Rows, value interface{}) (int, error) {
 			break
 		}
 	}
-	return count, nil
+	return count, rows.Err()
 }
 
 type dummyScanner struct{}


### PR DESCRIPTION
During [iteration](https://github.com/mailru/dbr/blob/master/load.go#L35) with [rows.Next()](https://pkg.go.dev/database/sql@go1.16.5#Rows.Next) some errors can appear. It will be saved to [Rows.lasterr](https://cs.opensource.google/go/go/+/refs/tags/go1.16.5:src/database/sql/sql.go;drc=422dc83baa2816ca1d9a0aa3f1aaf4c47c8098ad;l=2865), Next() will return **false** and iteration will be stopped.

Normal case is `Rows.lasterr == io.EOF`, then all data from db has been read. But there are other cases, for example - some transfer [problem](https://cs.opensource.google/go/go/+/refs/tags/go1.16.7:src/net/http/transfer.go;drc=1b09d430678d4a6f73b2443463d11f75851aba8a;l=906), then only part of data will be read and [Load](https://github.com/mailru/dbr/blob/master/load.go#L54) will not return this error.

So, it is required to check the latest error with [Rows.Err()](https://cs.opensource.google/go/go/+/refs/tags/go1.16.5:src/database/sql/sql.go;l=2930), it [returns](https://cs.opensource.google/go/go/+/refs/tags/go1.16.5:src/database/sql/sql.go;l=2796;drc=refs%2Ftags%2Fgo1.16.5) any `err != nil && err != io.EOF`.
