### PR TITLE
Fix ctx chain && Load method

### DIFF
--- a/delete_builder.go
+++ b/delete_builder.go
@@ -23,6 +23,7 @@ type deleteBuilder struct {
 	Dialect    Dialect
 	deleteStmt *deleteStmt
 	LimitCount int64
+	ctx        context.Context
 }
 
 // DeleteFrom creates a DeleteBuilder
@@ -33,6 +34,7 @@ func (sess *Session) DeleteFrom(table string) DeleteBuilder {
 		Dialect:       sess.Dialect,
 		deleteStmt:    createDeleteStmt(table),
 		LimitCount:    -1,
+		ctx:           sess.ctx,
 	}
 }
 
@@ -44,6 +46,7 @@ func (tx *Tx) DeleteFrom(table string) DeleteBuilder {
 		Dialect:       tx.Dialect,
 		deleteStmt:    createDeleteStmt(table),
 		LimitCount:    -1,
+		ctx:           tx.ctx,
 	}
 }
 
@@ -55,6 +58,7 @@ func (sess *Session) DeleteBySql(query string, value ...interface{}) DeleteBuild
 		Dialect:       sess.Dialect,
 		deleteStmt:    createDeleteStmtBySQL(query, value),
 		LimitCount:    -1,
+		ctx:           sess.ctx,
 	}
 }
 
@@ -66,12 +70,13 @@ func (tx *Tx) DeleteBySql(query string, value ...interface{}) DeleteBuilder {
 		Dialect:       tx.Dialect,
 		deleteStmt:    createDeleteStmtBySQL(query, value),
 		LimitCount:    -1,
+		ctx:           tx.ctx,
 	}
 }
 
 // Exec executes the stmt with background context
 func (b *deleteBuilder) Exec() (sql.Result, error) {
-	return b.ExecContext(context.Background())
+	return b.ExecContext(b.ctx)
 }
 
 // ExecContext executes the stmt

--- a/insert_builder.go
+++ b/insert_builder.go
@@ -27,6 +27,7 @@ type insertBuilder struct {
 	Dialect    Dialect
 	RecordID   reflect.Value
 	insertStmt *insertStmt
+	ctx        context.Context
 }
 
 // InsertInto creates a InsertBuilder
@@ -36,6 +37,7 @@ func (sess *Session) InsertInto(table string) InsertBuilder {
 		EventReceiver: sess.EventReceiver,
 		Dialect:       sess.Dialect,
 		insertStmt:    createInsertStmt(table),
+		ctx:           sess.ctx,
 	}
 }
 
@@ -46,6 +48,7 @@ func (tx *Tx) InsertInto(table string) InsertBuilder {
 		EventReceiver: tx.EventReceiver,
 		Dialect:       tx.Dialect,
 		insertStmt:    createInsertStmt(table),
+		ctx:           tx.ctx,
 	}
 }
 
@@ -56,6 +59,7 @@ func (sess *Session) InsertBySql(query string, value ...interface{}) InsertBuild
 		EventReceiver: sess.EventReceiver,
 		Dialect:       sess.Dialect,
 		insertStmt:    createInsertStmtBySQL(query, value),
+		ctx:           sess.ctx,
 	}
 }
 
@@ -66,6 +70,7 @@ func (tx *Tx) InsertBySql(query string, value ...interface{}) InsertBuilder {
 		EventReceiver: tx.EventReceiver,
 		Dialect:       tx.Dialect,
 		insertStmt:    createInsertStmtBySQL(query, value),
+		ctx:           tx.ctx,
 	}
 }
 
@@ -89,7 +94,7 @@ func (b *insertBuilder) Pair(column string, value interface{}) InsertBuilder {
 
 // Exec executes the stmt with background context
 func (b *insertBuilder) Exec() (sql.Result, error) {
-	return b.ExecContext(context.Background())
+	return b.ExecContext(b.ctx)
 }
 
 // ExecContext executes the stmt

--- a/load.go
+++ b/load.go
@@ -49,7 +49,13 @@ func Load(rows *sql.Rows, value interface{}) (int, error) {
 			break
 		}
 
-		v.Set(reflect.Append(v, elem))
+		if elemType.Kind() == reflect.Ptr {
+			elemCopy := reflect.New(elemType.Elem()).Elem()
+			elemCopy.Set(elem.Elem())
+			v.Set(reflect.Append(v, elemCopy.Addr()))
+		} else {
+			v.Set(reflect.Append(v, elem))
+		}
 	}
 
 	return count, rows.Err()

--- a/load_bench_test.go
+++ b/load_bench_test.go
@@ -72,20 +72,20 @@ func benchRawSQL(b *testing.B, data []benchItem, res []benchItem) {
 	b.StopTimer()
 	db, mock, err := sqlmock.New()
 	if err != nil {
-		panic(err)
+		b.Error(err)
 	}
 	mock.ExpectQuery("select").WillReturnRows(getRowsMocked(b, data))
 	b.StartTimer()
 
 	rows, err := db.Query("select")
 	if err != nil {
-		panic(err)
+		b.Error(err)
 	}
 
 	var item benchItem
 	for rows.Next() {
 		if err := rows.Scan(&item.Field1, &item.Field2); err != nil {
-			panic(err)
+			b.Error(err)
 		}
 		res = append(res, item)
 	}
@@ -93,32 +93,32 @@ func benchRawSQL(b *testing.B, data []benchItem, res []benchItem) {
 
 func benchDBR(b *testing.B, data []benchItem, res []benchItem) {
 	b.StopTimer()
-	sess, dbmock := getDBRMock(dialect.MySQL)
+	sess, dbmock := getDBRMock(b, dialect.MySQL)
 	dbmock.ExpectQuery("SELECT field1, field2 FROM sometable").WillReturnRows(getRowsMocked(b, data))
 	rows := sess.Select("field1", "field2").From("sometable")
 	b.StartTimer()
 
 	if _, err := rows.LoadStructs(&res); err != nil {
-		panic(err)
+		b.Error(err)
 	}
 }
 
 func benchDBRPtrs(b *testing.B, data []benchItem, res []*benchItem) {
 	b.StopTimer()
-	sess, dbmock := getDBRMock(dialect.MySQL)
+	sess, dbmock := getDBRMock(b, dialect.MySQL)
 	dbmock.ExpectQuery("SELECT field1, field2 FROM sometable").WillReturnRows(getRowsMocked(b, data))
 	rows := sess.Select("field1", "field2").From("sometable")
 	b.StartTimer()
 
 	if _, err := rows.LoadStructs(&res); err != nil {
-		panic(err)
+		b.Error(err)
 	}
 }
 
-func getDBRMock(dialect dbr.Dialect) (*dbr.Session, sqlmock.Sqlmock) {
+func getDBRMock(b *testing.B, dialect dbr.Dialect) (*dbr.Session, sqlmock.Sqlmock) {
 	db, dbmock, err := sqlmock.New()
 	if err != nil {
-		panic(err)
+		b.Error(err)
 	}
 
 	conn := dbr.Connection{DB: db, Dialect: dialect, EventReceiver: &dbr.NullEventReceiver{}}

--- a/load_test.go
+++ b/load_test.go
@@ -98,7 +98,7 @@ func newSessionMock() (SessionRunner, sqlmock.Sqlmock) {
 func Test_Load_Scalar(t *testing.T) {
 	t.Parallel()
 	var res int
-	_, err := Load(sqlRows(sqlmock.NewRows([]string{"cnt"}).AddRow(123)), &res)
+	_, err := Load(sqlRows(t, sqlmock.NewRows([]string{"cnt"}).AddRow(123)), &res)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 123, res)
 }
@@ -106,7 +106,7 @@ func Test_Load_Scalar(t *testing.T) {
 func Test_Load_ScalarPtr(t *testing.T) {
 	t.Parallel()
 	var res *int
-	_, err := Load(sqlRows(sqlmock.NewRows([]string{"cnt"}).AddRow(123)), &res)
+	_, err := Load(sqlRows(t, sqlmock.NewRows([]string{"cnt"}).AddRow(123)), &res)
 	assert.NoError(t, err)
 	expected := new(int)
 	*expected = 123
@@ -116,7 +116,7 @@ func Test_Load_ScalarPtr(t *testing.T) {
 func Test_Load_ScalarSlice(t *testing.T) {
 	t.Parallel()
 	var res []int
-	_, err := Load(sqlRows(sqlmock.NewRows([]string{"cnt"}).AddRow(111).AddRow(222).AddRow(333)), &res)
+	_, err := Load(sqlRows(t, sqlmock.NewRows([]string{"cnt"}).AddRow(111).AddRow(222).AddRow(333)), &res)
 	assert.NoError(t, err)
 	assert.EqualValues(t, []int{111, 222, 333}, res)
 }
@@ -124,7 +124,7 @@ func Test_Load_ScalarSlice(t *testing.T) {
 func Test_Load_ScalarSlicePtr(t *testing.T) {
 	t.Parallel()
 	var expected, actual []*int
-	_, err := Load(sqlRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0).AddRow(1).AddRow(2)), &actual)
+	_, err := Load(sqlRows(t, sqlmock.NewRows([]string{"cnt"}).AddRow(0).AddRow(1).AddRow(2)), &actual)
 	assert.NoError(t, err)
 	for k := range make([]int, 3) {
 		k := k
@@ -141,7 +141,7 @@ type testObj struct {
 func Test_Load_Struct(t *testing.T) {
 	t.Parallel()
 	var res testObj
-	_, err := Load(sqlRows(sqlmock.NewRows([]string{"field1", "field2"}).AddRow("111", 222)), &res)
+	_, err := Load(sqlRows(t, sqlmock.NewRows([]string{"field1", "field2"}).AddRow("111", 222)), &res)
 	assert.NoError(t, err)
 	assert.EqualValues(t, testObj{"111", 222}, res)
 }
@@ -149,7 +149,7 @@ func Test_Load_Struct(t *testing.T) {
 func Test_Load_StructPtr(t *testing.T) {
 	t.Parallel()
 	res := &testObj{}
-	_, err := Load(sqlRows(sqlmock.NewRows([]string{"field1", "field2"}).AddRow("111", 222)), &res)
+	_, err := Load(sqlRows(t, sqlmock.NewRows([]string{"field1", "field2"}).AddRow("111", 222)), &res)
 	assert.NoError(t, err)
 	assert.EqualValues(t, &testObj{"111", 222}, res)
 }
@@ -157,7 +157,7 @@ func Test_Load_StructPtr(t *testing.T) {
 func Test_Load_StructSlice(t *testing.T) {
 	t.Parallel()
 	var res []testObj
-	_, err := Load(sqlRows(sqlmock.NewRows([]string{"field1", "field2"}).AddRow("111", 222).AddRow("222", 333)), &res)
+	_, err := Load(sqlRows(t, sqlmock.NewRows([]string{"field1", "field2"}).AddRow("111", 222).AddRow("222", 333)), &res)
 	assert.NoError(t, err)
 	assert.EqualValues(t, []testObj{{"111", 222}, {"222", 333}}, res)
 }
@@ -165,7 +165,7 @@ func Test_Load_StructSlice(t *testing.T) {
 func Test_Load_StructSlicePtr(t *testing.T) {
 	t.Parallel()
 	var expected, actual []*testObj
-	_, err := Load(sqlRows(sqlmock.NewRows([]string{"field1", "field2"}).AddRow("0", 0).AddRow("1", 1)), &actual)
+	_, err := Load(sqlRows(t, sqlmock.NewRows([]string{"field1", "field2"}).AddRow("0", 0).AddRow("1", 1)), &actual)
 	assert.NoError(t, err)
 	for k := range make([]int, 2) {
 		k := k
@@ -174,16 +174,19 @@ func Test_Load_StructSlicePtr(t *testing.T) {
 	assert.EqualValues(t, expected, actual)
 }
 
-func sqlRows(mockedRows *sqlmock.Rows) *sql.Rows {
+func sqlRows(t *testing.T, mockedRows *sqlmock.Rows) *sql.Rows {
+	t.Helper()
+
 	db, dbmock, err := sqlmock.New()
 	if err != nil {
-		panic(err)
+		t.Error(err)
 	}
+
 	dbmock.ExpectQuery("select").WillReturnRows(mockedRows)
 
 	rows, err := db.Query("select")
 	if err != nil {
-		panic(err)
+		t.Error(err)
 	}
 
 	return rows

--- a/load_test.go
+++ b/load_test.go
@@ -1,7 +1,9 @@
 package dbr
 
 import (
+	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -91,4 +93,98 @@ func newSessionMock() (SessionRunner, sqlmock.Sqlmock) {
 	}
 	conn := Connection{DB: db, Dialect: dialect.MySQL, EventReceiver: nullReceiver}
 	return conn.NewSession(nil), m
+}
+
+func Test_Load_Scalar(t *testing.T) {
+	t.Parallel()
+	var res int
+	_, err := Load(sqlRows(sqlmock.NewRows([]string{"cnt"}).AddRow(123)), &res)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 123, res)
+}
+
+func Test_Load_ScalarPtr(t *testing.T) {
+	t.Parallel()
+	var res *int
+	_, err := Load(sqlRows(sqlmock.NewRows([]string{"cnt"}).AddRow(123)), &res)
+	assert.NoError(t, err)
+	expected := new(int)
+	*expected = 123
+	assert.EqualValues(t, expected, res)
+}
+
+func Test_Load_ScalarSlice(t *testing.T) {
+	t.Parallel()
+	var res []int
+	_, err := Load(sqlRows(sqlmock.NewRows([]string{"cnt"}).AddRow(111).AddRow(222).AddRow(333)), &res)
+	assert.NoError(t, err)
+	assert.EqualValues(t, []int{111, 222, 333}, res)
+}
+
+func Test_Load_ScalarSlicePtr(t *testing.T) {
+	t.Parallel()
+	var expected, actual []*int
+	_, err := Load(sqlRows(sqlmock.NewRows([]string{"cnt"}).AddRow(0).AddRow(1).AddRow(2)), &actual)
+	assert.NoError(t, err)
+	for k := range make([]int, 3) {
+		k := k
+		expected = append(expected, &k)
+	}
+	assert.EqualValues(t, expected, actual)
+}
+
+type testObj struct {
+	Field1 string
+	Field2 int
+}
+
+func Test_Load_Struct(t *testing.T) {
+	t.Parallel()
+	var res testObj
+	_, err := Load(sqlRows(sqlmock.NewRows([]string{"field1", "field2"}).AddRow("111", 222)), &res)
+	assert.NoError(t, err)
+	assert.EqualValues(t, testObj{"111", 222}, res)
+}
+
+func Test_Load_StructPtr(t *testing.T) {
+	t.Parallel()
+	res := &testObj{}
+	_, err := Load(sqlRows(sqlmock.NewRows([]string{"field1", "field2"}).AddRow("111", 222)), &res)
+	assert.NoError(t, err)
+	assert.EqualValues(t, &testObj{"111", 222}, res)
+}
+
+func Test_Load_StructSlice(t *testing.T) {
+	t.Parallel()
+	var res []testObj
+	_, err := Load(sqlRows(sqlmock.NewRows([]string{"field1", "field2"}).AddRow("111", 222).AddRow("222", 333)), &res)
+	assert.NoError(t, err)
+	assert.EqualValues(t, []testObj{{"111", 222}, {"222", 333}}, res)
+}
+
+func Test_Load_StructSlicePtr(t *testing.T) {
+	t.Parallel()
+	var expected, actual []*testObj
+	_, err := Load(sqlRows(sqlmock.NewRows([]string{"field1", "field2"}).AddRow("0", 0).AddRow("1", 1)), &actual)
+	assert.NoError(t, err)
+	for k := range make([]int, 2) {
+		k := k
+		expected = append(expected, &testObj{fmt.Sprint(k), k})
+	}
+	assert.EqualValues(t, expected, actual)
+}
+
+func sqlRows(mockedRows *sqlmock.Rows) *sql.Rows {
+	db, dbmock, err := sqlmock.New()
+	if err != nil {
+		panic(err)
+	}
+	dbmock.ExpectQuery("select").WillReturnRows(mockedRows)
+
+	rows, err := db.Query("select")
+	if err != nil {
+		panic(err)
+	}
+
+	return rows
 }

--- a/select_builder.go
+++ b/select_builder.go
@@ -36,7 +36,8 @@ type SelectBuilder interface {
 	RightJoin(table, on interface{}) SelectBuilder
 	SkipLocked() SelectBuilder
 	Where(query interface{}, value ...interface{}) SelectBuilder
-	GetRows(context.Context) (*sql.Rows, error)
+	GetRows() (*sql.Rows, error)
+	GetRowsContext(context.Context) (*sql.Rows, error)
 }
 
 type selectBuilder struct {
@@ -178,7 +179,12 @@ func (b *selectBuilder) LoadStructsContext(ctx context.Context, value interface{
 }
 
 // GetRows returns sql.Rows from query result.
-func (b *selectBuilder) GetRows(ctx context.Context) (*sql.Rows, error) {
+func (b *selectBuilder) GetRows() (*sql.Rows, error) {
+	return b.GetRowsContext(b.ctx)
+}
+
+// GetRowsContext returns sql.Rows from query result.
+func (b *selectBuilder) GetRowsContext(ctx context.Context) (*sql.Rows, error) {
 	rows, _, err := queryRows(ctx, b.runner, b.EventReceiver, b, b.Dialect)
 
 	return rows, err

--- a/select_builder.go
+++ b/select_builder.go
@@ -46,6 +46,7 @@ type selectBuilder struct {
 	Dialect    Dialect
 	selectStmt *selectStmt
 	timezone   *time.Location
+	ctx        context.Context
 }
 
 func prepareSelect(a []string) []interface{} {
@@ -63,6 +64,7 @@ func (sess *Session) Select(column ...string) SelectBuilder {
 		EventReceiver: sess.EventReceiver,
 		Dialect:       sess.Dialect,
 		selectStmt:    createSelectStmt(prepareSelect(column)),
+		ctx:           sess.ctx,
 	}
 }
 
@@ -73,6 +75,7 @@ func (tx *Tx) Select(column ...string) SelectBuilder {
 		EventReceiver: tx.EventReceiver,
 		Dialect:       tx.Dialect,
 		selectStmt:    createSelectStmt(prepareSelect(column)),
+		ctx:           tx.ctx,
 	}
 }
 
@@ -83,6 +86,7 @@ func (sess *Session) SelectBySql(query string, value ...interface{}) SelectBuild
 		EventReceiver: sess.EventReceiver,
 		Dialect:       sess.Dialect,
 		selectStmt:    createSelectStmtBySQL(query, value),
+		ctx:           sess.ctx,
 	}
 }
 
@@ -93,6 +97,7 @@ func (tx *Tx) SelectBySql(query string, value ...interface{}) SelectBuilder {
 		EventReceiver: tx.EventReceiver,
 		Dialect:       tx.Dialect,
 		selectStmt:    createSelectStmtBySQL(query, value),
+		ctx:           tx.ctx,
 	}
 }
 
@@ -126,7 +131,7 @@ func (b *selectBuilder) Build(d Dialect, buf Buffer) error {
 
 // Load loads any value from query result with background context
 func (b *selectBuilder) Load(value interface{}) (int, error) {
-	return b.LoadContext(context.Background(), value)
+	return b.LoadContext(b.ctx, value)
 }
 
 // LoadContext loads any value from query result
@@ -140,7 +145,7 @@ func (b *selectBuilder) LoadContext(ctx context.Context, value interface{}) (int
 
 // LoadStruct loads struct from query result with background context, returns ErrNotFound if there is no result
 func (b *selectBuilder) LoadStruct(value interface{}) error {
-	return b.LoadStructContext(context.Background(), value)
+	return b.LoadStructContext(b.ctx, value)
 }
 
 // LoadStructContext loads struct from query result, returns ErrNotFound if there is no result
@@ -160,7 +165,7 @@ func (b *selectBuilder) LoadStructContext(ctx context.Context, value interface{}
 
 // LoadStructs loads structures from query result with background context
 func (b *selectBuilder) LoadStructs(value interface{}) (int, error) {
-	return b.LoadStructsContext(context.Background(), value)
+	return b.LoadStructsContext(b.ctx, value)
 }
 
 // LoadStructsContext loads structures from query result
@@ -181,7 +186,7 @@ func (b *selectBuilder) GetRows(ctx context.Context) (*sql.Rows, error) {
 
 // LoadValue loads any value from query result with background context, returns ErrNotFound if there is no result
 func (b *selectBuilder) LoadValue(value interface{}) error {
-	return b.LoadValueContext(context.Background(), value)
+	return b.LoadValueContext(b.ctx, value)
 }
 
 // LoadValueContext loads any value from query result, returns ErrNotFound if there is no result
@@ -201,7 +206,7 @@ func (b *selectBuilder) LoadValueContext(ctx context.Context, value interface{})
 
 // LoadValues loads any values from query result with background context
 func (b *selectBuilder) LoadValues(value interface{}) (int, error) {
-	return b.LoadValuesContext(context.Background(), value)
+	return b.LoadValuesContext(b.ctx, value)
 }
 
 // LoadValuesContext loads any values from query result

--- a/update_builder.go
+++ b/update_builder.go
@@ -25,6 +25,7 @@ type updateBuilder struct {
 	Dialect    Dialect
 	updateStmt *updateStmt
 	LimitCount int64
+	ctx        context.Context
 }
 
 // Update creates a UpdateBuilder
@@ -35,6 +36,7 @@ func (sess *Session) Update(table string) UpdateBuilder {
 		Dialect:       sess.Dialect,
 		updateStmt:    createUpdateStmt(table),
 		LimitCount:    -1,
+		ctx:           sess.ctx,
 	}
 }
 
@@ -46,6 +48,7 @@ func (tx *Tx) Update(table string) UpdateBuilder {
 		Dialect:       tx.Dialect,
 		updateStmt:    createUpdateStmt(table),
 		LimitCount:    -1,
+		ctx:           tx.ctx,
 	}
 }
 
@@ -57,6 +60,7 @@ func (sess *Session) UpdateBySql(query string, value ...interface{}) UpdateBuild
 		Dialect:       sess.Dialect,
 		updateStmt:    createUpdateStmtBySQL(query, value),
 		LimitCount:    -1,
+		ctx:           sess.ctx,
 	}
 }
 
@@ -68,12 +72,13 @@ func (tx *Tx) UpdateBySql(query string, value ...interface{}) UpdateBuilder {
 		Dialect:       tx.Dialect,
 		updateStmt:    createUpdateStmtBySQL(query, value),
 		LimitCount:    -1,
+		ctx:           tx.ctx,
 	}
 }
 
 // Exec executes the stmt with background context
 func (b *updateBuilder) Exec() (sql.Result, error) {
-	return b.ExecContext(context.Background())
+	return b.ExecContext(b.ctx)
 }
 
 // ExecContext executes the stmt


### PR DESCRIPTION
Исправляем:
1. Обрыв цепочки контекста в методах Load(), LoadStruct(), LoadStructs() и т.д.
2. Баг в рефлексии в методе Load(), в случае если передали слайс ссылок ([]*int, []*struct{} и т.д.)