### PR TITLE
sql.DB interface

### DIFF
--- a/dbr.go
+++ b/dbr.go
@@ -3,6 +3,7 @@ package dbr
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"time"
 
@@ -109,6 +110,9 @@ type DBConn interface {
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 	QueryRow(query string, args ...interface{}) *sql.Row
 
+	Stats() sql.DBStats
+	Driver() driver.Driver
+	Conn(ctx context.Context) (*sql.Conn, error)
 	Close() error
 }
 

--- a/dbr.go
+++ b/dbr.go
@@ -32,7 +32,7 @@ func Open(driver, dsn string, log EventReceiver) (*Connection, error) {
 	default:
 		return nil, ErrNotSupported
 	}
-	return &Connection{DB: conn, EventReceiver: log, Dialect: d}, nil
+	return &Connection{DBConn: conn, EventReceiver: log, Dialect: d}, nil
 }
 
 const (
@@ -42,7 +42,7 @@ const (
 // Connection is a connection to the database with an EventReceiver
 // to send events, errors, and timings to
 type Connection struct {
-	*sql.DB
+	DBConn
 	Dialect Dialect
 	EventReceiver
 }
@@ -93,6 +93,23 @@ type SessionRunner interface {
 
 	DeleteFrom(table string) DeleteBuilder
 	DeleteBySql(query string, value ...interface{}) DeleteBuilder
+}
+
+// DBConn interface for sql.DB
+type DBConn interface {
+	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
+	Begin() (*sql.Tx, error)
+
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	Exec(query string, args ...interface{}) (sql.Result, error)
+
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	QueryRow(query string, args ...interface{}) *sql.Row
+
+	Close() error
 }
 
 type runner interface {

--- a/load_bench_test.go
+++ b/load_bench_test.go
@@ -121,7 +121,7 @@ func getDBRMock(b *testing.B, dialect dbr.Dialect) (*dbr.Session, sqlmock.Sqlmoc
 		b.Error(err)
 	}
 
-	conn := dbr.Connection{DB: db, Dialect: dialect, EventReceiver: &dbr.NullEventReceiver{}}
+	conn := dbr.Connection{DBConn: db, Dialect: dialect, EventReceiver: &dbr.NullEventReceiver{}}
 
 	return conn.NewSession(conn.EventReceiver), dbmock
 }

--- a/load_test.go
+++ b/load_test.go
@@ -91,7 +91,7 @@ func newSessionMock() (SessionRunner, sqlmock.Sqlmock) {
 	if err != nil {
 		panic(err)
 	}
-	conn := Connection{DB: db, Dialect: dialect.MySQL, EventReceiver: nullReceiver}
+	conn := Connection{DBConn: db, Dialect: dialect.MySQL, EventReceiver: nullReceiver}
 	return conn.NewSession(nil), m
 }
 


### PR DESCRIPTION
Замена *sql.DB на интерфейс, для добавления возможности декорирования или мока sql-клиента